### PR TITLE
Feature/allow setting key

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "author": "Tomas Alabes",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "format": "prettier --write src",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   "author": "Tomas Alabes",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "build": "tsc",
     "format": "prettier --write src",

--- a/src/kafka-pubsub.ts
+++ b/src/kafka-pubsub.ts
@@ -80,6 +80,7 @@ export class KafkaPubSub implements PubSubEngine {
   public async publish(
     channel: string,
     payload: string | Buffer,
+    key: string | Buffer,
     headers?: IHeaders,
     sendOptions?: object
   ): Promise<void> {
@@ -87,6 +88,7 @@ export class KafkaPubSub implements PubSubEngine {
       messages: [
         {
           value: payload,
+          key,
           headers: {
             ...headers,
             channel,

--- a/src/kafka-pubsub.ts
+++ b/src/kafka-pubsub.ts
@@ -74,13 +74,14 @@ export class KafkaPubSub implements PubSubEngine {
    *
    * @param channel to use for internal routing, besides topic
    * @param payload event to send
+   * @param key the key of the event
    * @param headers optional kafkajs headers
    * @param sendOptions optional kafkajs producer.send options
    */
   public async publish(
     channel: string,
     payload: string | Buffer,
-    key: string | Buffer,
+    key?: string | Buffer,
     headers?: IHeaders,
     sendOptions?: object
   ): Promise<void> {

--- a/src/kafka-pubsub.ts
+++ b/src/kafka-pubsub.ts
@@ -81,9 +81,9 @@ export class KafkaPubSub implements PubSubEngine {
   public async publish(
     channel: string,
     payload: string | Buffer,
-    key?: string | Buffer,
     headers?: IHeaders,
-    sendOptions?: object
+    sendOptions?: object,
+    key?: string | Buffer,
   ): Promise<void> {
     await this.producer.send({
       messages: [

--- a/src/test/kafka-pubsub.spec.ts
+++ b/src/test/kafka-pubsub.spec.ts
@@ -61,7 +61,7 @@ describe("Test Suite", () => {
     await pubsub.subscribe(channel, onMessage);
 
     const headers = { custom: "header" };
-    await pubsub.publish(channel, payload, undefined, headers);
+    await pubsub.publish(channel, payload, headers);
     expect(onMessage).toBeCalled();
     expect(onMessage).toBeCalledWith({
       value: payload,
@@ -87,7 +87,7 @@ describe("Test Suite", () => {
 
     await pubsub.subscribe(channel, onMessage);
 
-    await pubsub.publish(channel, payload, key);
+    await pubsub.publish(channel, payload, undefined, undefined, key);
     expect(onMessage).toBeCalled();
     expect(onMessage).toBeCalledWith({
       value: payload,

--- a/src/test/kafka-pubsub.spec.ts
+++ b/src/test/kafka-pubsub.spec.ts
@@ -61,12 +61,38 @@ describe("Test Suite", () => {
     await pubsub.subscribe(channel, onMessage);
 
     const headers = { custom: "header" };
-    await pubsub.publish(channel, payload, headers);
+    await pubsub.publish(channel, payload, undefined, headers);
     expect(onMessage).toBeCalled();
     expect(onMessage).toBeCalledWith({
       value: payload,
       headers: {
         ...headers,
+        channel,
+      },
+    });
+  });
+  it("should test basic pub sub with custom key", async () => {
+    const topic = "mock_topic";
+    const channel = "my_channel";
+    const payload = JSON.stringify({ data: 1 });
+    const key = "test-key";
+
+    const onMessage = jest.fn((msg: KafkaMessage) => {});
+
+    const pubsub = await KafkaPubSub.create({
+      groupIdPrefix: "my-prefix",
+      kafka: new Kafka() as any,
+      topic,
+    });
+
+    await pubsub.subscribe(channel, onMessage);
+
+    await pubsub.publish(channel, payload, key);
+    expect(onMessage).toBeCalled();
+    expect(onMessage).toBeCalledWith({
+      value: payload,
+      key,
+      headers: {
         channel,
       },
     });


### PR DESCRIPTION
@tomasAlabes
@ancashoria

I noticed while using this project that I could not set the key on produced messages.

- Added an optional parameter to set the key on published messages.
- Added a test case to test that they key is sent on the kafkajs produce call.
- Updated existing test case to reflect new parameter ordering.

please let me know if you would like any other changes, bumped version, etc. This is a breaking change