### PR TITLE
feat: add resolve channel from message method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ export const pubsub = KafkaPubSub.create({
   groupIdPrefix: "my-group-id-prefix", // used for kafka pub/sub,
   producerConfig: {}, // optional kafkajs producer configuration
   consumerConfig: {} // optional kafkajs consumer configuration
+  resolveChannelFromMessage: () => "my channel" // optional function to resolve the channel from the message, by default message.headers.channel will be used
 })
 ```
 
@@ -78,11 +79,15 @@ pubsub.publish("my channel", {
 Use the rest of the kafkajs options:
 
 ```javascript
-const event = {/* ... */};
-const headers = {
-  header1: "value"
+const event = {
+  /* ... */
 };
-const producerOptions = { /* options from kafka.js.org/docs/producing: acks, timeout, etc */ };
+const headers = {
+  header1: "value",
+};
+const producerOptions = {
+  /* options from kafka.js.org/docs/producing: acks, timeout, etc */
+};
 
 pubsub.publish("my channel", event, headers, producerOptions);
 ```

--- a/src/kafka-pubsub.ts
+++ b/src/kafka-pubsub.ts
@@ -16,12 +16,17 @@ interface KafkaPubSubInput {
   groupIdPrefix: string;
   producerConfig?: ProducerConfig;
   consumerConfig?: Omit<ConsumerConfig, "groupId">;
+  resolveChannelFromMessage?: MessageHandler;
 }
 
 export type MessageHandler = (msg: KafkaMessage) => any;
 
 interface SubscriptionsMap {
   [subId: number]: [string, MessageHandler];
+}
+
+function defaultChannelResolver(message: KafkaMessage): string {
+  return message.headers?.channel as string;
 }
 
 export class KafkaPubSub implements PubSubEngine {
@@ -31,6 +36,7 @@ export class KafkaPubSub implements PubSubEngine {
   private producer: Producer;
   private consumer: Consumer;
   private topic: string;
+  private resolveChannelFromMessage: MessageHandler;
 
   public static async create({
     kafka,
@@ -38,6 +44,7 @@ export class KafkaPubSub implements PubSubEngine {
     groupIdPrefix,
     producerConfig = {},
     consumerConfig = {},
+    resolveChannelFromMessage = defaultChannelResolver
   }: KafkaPubSubInput): Promise<KafkaPubSub> {
     const pubsub = new KafkaPubSub({
       kafka,
@@ -45,6 +52,7 @@ export class KafkaPubSub implements PubSubEngine {
       groupIdPrefix,
       producerConfig,
       consumerConfig,
+      resolveChannelFromMessage,
     });
     await pubsub.connectProducer();
     await pubsub.runConsumer(pubsub.topic);
@@ -57,6 +65,7 @@ export class KafkaPubSub implements PubSubEngine {
     groupIdPrefix,
     producerConfig,
     consumerConfig,
+    resolveChannelFromMessage
   }: KafkaPubSubInput) {
     this.client = kafka;
     this.subscriptionMap = {};
@@ -68,6 +77,7 @@ export class KafkaPubSub implements PubSubEngine {
       // we need all consumers listening to all messages
       groupId: `${groupIdPrefix}-${Math.ceil(Math.random() * 9999)}`,
     });
+    this.resolveChannelFromMessage = resolveChannelFromMessage
   }
 
   /**
@@ -145,12 +155,12 @@ export class KafkaPubSub implements PubSubEngine {
     await this.consumer.subscribe({ topic });
     await this.consumer.run({
       eachMessage: async ({ message }) => {
-        // Using channel abstraction
-        if (message.headers?.channel) {
-          this.onMessage(message.headers.channel as string, message);
+        const channel = this.resolveChannelFromMessage(message)
+
+        if (channel) {
+            this.onMessage(channel, message);
         } else {
-          // No channel abstraction, publish over the whole topic
-          this.onMessage(topic, message);
+            this.onMessage(topic, message);
         }
       },
     });

--- a/src/kafka-pubsub.ts
+++ b/src/kafka-pubsub.ts
@@ -44,7 +44,7 @@ export class KafkaPubSub implements PubSubEngine {
     groupIdPrefix,
     producerConfig = {},
     consumerConfig = {},
-    resolveChannelFromMessage = defaultChannelResolver
+    resolveChannelFromMessage = defaultChannelResolver,
   }: KafkaPubSubInput): Promise<KafkaPubSub> {
     const pubsub = new KafkaPubSub({
       kafka,
@@ -65,7 +65,7 @@ export class KafkaPubSub implements PubSubEngine {
     groupIdPrefix,
     producerConfig,
     consumerConfig,
-    resolveChannelFromMessage
+    resolveChannelFromMessage,
   }: KafkaPubSubInput) {
     this.client = kafka;
     this.subscriptionMap = {};
@@ -77,7 +77,7 @@ export class KafkaPubSub implements PubSubEngine {
       // we need all consumers listening to all messages
       groupId: `${groupIdPrefix}-${Math.ceil(Math.random() * 9999)}`,
     });
-    this.resolveChannelFromMessage = resolveChannelFromMessage
+    this.resolveChannelFromMessage = resolveChannelFromMessage;
   }
 
   /**
@@ -93,7 +93,7 @@ export class KafkaPubSub implements PubSubEngine {
     payload: string | Buffer,
     headers?: IHeaders,
     sendOptions?: object,
-    key?: string | Buffer,
+    key?: string | Buffer
   ): Promise<void> {
     await this.producer.send({
       messages: [
@@ -155,12 +155,12 @@ export class KafkaPubSub implements PubSubEngine {
     await this.consumer.subscribe({ topic });
     await this.consumer.run({
       eachMessage: async ({ message }) => {
-        const channel = this.resolveChannelFromMessage(message)
+        const channel = this.resolveChannelFromMessage(message);
 
         if (channel) {
-            this.onMessage(channel, message);
+          this.onMessage(channel, message);
         } else {
-            this.onMessage(topic, message);
+          this.onMessage(topic, message);
         }
       },
     });

--- a/src/test/kafka-pubsub.spec.ts
+++ b/src/test/kafka-pubsub.spec.ts
@@ -24,6 +24,32 @@ describe("Test Suite", () => {
       headers: { channel },
     });
   });
+
+  it("should test basic pub sub with custom channel resolver", async () => {
+    const topic = "mock_topic";
+    const channel = "my_channel";
+    const payload = Buffer.from(JSON.stringify({ data: 'customKey' }));
+
+    const onMessage = jest.fn((msg: KafkaMessage) => {});
+
+    const pubsub = await KafkaPubSub.create({
+      groupIdPrefix: "my-prefix",
+      kafka: new Kafka() as any,
+      topic,
+      resolveChannelFromMessage(msg) {
+        return JSON.parse(msg.value.toString()).data;
+      }
+    });
+
+    await pubsub.subscribe('customKey', onMessage);
+    await pubsub.publish(channel, payload);
+    expect(onMessage).toBeCalled();
+    expect(onMessage).toBeCalledWith({
+      value: payload,
+      headers: { channel },
+    });
+  });
+
   it("should test basic pub sub with stringified payload", async () => {
     const topic = "mock_topic";
     const channel = "my_channel";

--- a/src/test/kafka-pubsub.spec.ts
+++ b/src/test/kafka-pubsub.spec.ts
@@ -28,7 +28,7 @@ describe("Test Suite", () => {
   it("should test basic pub sub with custom channel resolver", async () => {
     const topic = "mock_topic";
     const channel = "my_channel";
-    const payload = Buffer.from(JSON.stringify({ data: 'customKey' }));
+    const payload = Buffer.from(JSON.stringify({ data: "customKey" }));
 
     const onMessage = jest.fn((msg: KafkaMessage) => {});
 
@@ -38,10 +38,10 @@ describe("Test Suite", () => {
       topic,
       resolveChannelFromMessage(msg) {
         return JSON.parse(msg.value.toString()).data;
-      }
+      },
     });
 
-    await pubsub.subscribe('customKey', onMessage);
+    await pubsub.subscribe("customKey", onMessage);
     await pubsub.publish(channel, payload);
     expect(onMessage).toBeCalled();
     expect(onMessage).toBeCalledWith({


### PR DESCRIPTION
We have an special case in which the channel is inside the payload and not on the headers. I think it will be nice to allow the user to chose where to get the channel id.
